### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ADD server.py .
 
 # Add your model weight files 
 # (in this case we have a python script)
+
+#Alternative to using build args, you can put your token in the next line
+#ENV HF_AUTH_TOKEN={token}
 ARG HF_AUTH_TOKEN
 ADD download.py .
 RUN python3 download.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ADD server.py .
 
 # Add your model weight files 
 # (in this case we have a python script)
+ARG HF_AUTH_TOKEN
 ADD download.py .
 RUN python3 download.py
 

--- a/download.py
+++ b/download.py
@@ -1,13 +1,14 @@
 # In this file, we define download_model
 # It runs during container build time to get model weights built into the container
 
-# In this example: A Huggingface BERT model
-
-from transformers import pipeline
+from diffusers import StableDiffusionPipeline, LMSDiscreteScheduler
+import os
 
 def download_model():
     # do a dry run of loading the huggingface model, which will download weights at build time
-    
+    #Set auth token which is required to download stable diffusion model weights
+    HF_AUTH_TOKEN = os.getenv("HF_AUTH_TOKEN")
+
     lms = LMSDiscreteScheduler(
         beta_start=0.00085, 
         beta_end=0.012, 
@@ -17,8 +18,8 @@ def download_model():
     model = StableDiffusionPipeline.from_pretrained(
         "CompVis/stable-diffusion-v1-4", 
         scheduler=lms,
-        use_auth_token=True
-    ).to("cuda")
+        use_auth_token=HF_AUTH_TOKEN
+    )
 
 if __name__ == "__main__":
     download_model()


### PR DESCRIPTION
# What is this?
 Added HF_AUTH_TOKEN build time arg so the download.py script has access to it during docker build
# Why?
 HuggingFace requires the auth token to download stable diffusion weights
# How did you test it? 
 Tested Docker build locally and it works