### PR TITLE
add token env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ ADD app.py .
 
 EXPOSE 8000
 
+ENV HF_AUTH_TOKEN=$HF_AUTH_TOKEN
 CMD python3 -u server.py


### PR DESCRIPTION
# What is this?
 Add HF_AUTH_TOKEN as ENV as well so app.py can access it at runtime
# Why?
 Even though model is already downloaded, the token is required at runtime as well
# How did you test it? 
 Built and running inferences locally, building right now through banana