### PR TITLE
cleaned readme for specifically stable diffusion related content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,21 +13,17 @@ RUN pip3 install -r requirements.txt
 
 # We add the banana boilerplate here
 ADD server.py .
+EXPOSE 8000
+
+# Add your huggingface auth key here
+ENV HF_AUTH_TOKEN=your_token
 
 # Add your model weight files 
 # (in this case we have a python script)
-
-#Alternative to using build args, you can put your token in the next line
-#ENV HF_AUTH_TOKEN={token}
-ARG HF_AUTH_TOKEN
 ADD download.py .
 RUN python3 download.py
-
 
 # Add your custom app code, init() and inference()
 ADD app.py .
 
-EXPOSE 8000
-
-ENV HF_AUTH_TOKEN=$HF_AUTH_TOKEN
 CMD python3 -u server.py

--- a/README.md
+++ b/README.md
@@ -3,38 +3,8 @@
 
 This repo gives a basic framework for serving Stable Diffusion in production using simple HTTP servers.
 
-NOTE: the template requires you to configure your huggingface auth key into it before it works. Read "Quickstart" below for instructions.
-
-If you want to generalize this to deploy anything on Banana, [see the guide here](https://www.notion.so/banana-dev/How-To-Serve-Anything-On-Banana-125a65fc4d30496ba1408de1d64d052a).
-
 ## Quickstart:
 
-The repo is already set up to run [Stable Diffusion](https://huggingface.co/CompVis/stable-diffusion-v1-4) text-to-image model.
-1. Run `pip3 install -r requirements.txt` to download dependencies.
-2. Set your Huggingface Auth Token as an environment variable `export HF_AUTH_TOKEN=your_auth_token`
-3. Add your HF_AUTH_TOKEN environment variable to the dockerfile, or [contact the Banana team](https://www.banana.dev/contact) to set it privately as a build arg.
-4. Run `python3 server.py` to start the server.
-5. Run `python3 test.py` in a different terminal session to test against it.
-
-## Make it your own:
-
-1. Edit `app.py` to load and run your model.
-2. Make sure to test with `test.py`!
-3. When ready to deploy:
-  - edit `download.py` (or the `Dockerfile` itself) with scripts download your custom model weights at build time
-  - edit `requirements.txt` with your pip packages. Don't delete the "sanic" line, as it's a banana dependency.
-
-## Move to prod:
-
-At this point, you have a functioning http server for your ML model. You can use it as is, or package it up with our provided `Dockerfile` and deploy it to your favorite container hosting provider!
-
-If Banana is your favorite GPU hosting provider (and we sure hope it is), read on!
-
-# 🍌
-
-# Deploy to Banana Serverless:
-
-Three steps:
 1. Create your own copy of this template repo. Either:
 - Click "Fork" on this repo (creates a public repo)
 - Create your own repo and copy the template files into it (to create a private repo)
@@ -43,7 +13,12 @@ Three steps:
 
 3. Login in to the [Banana Dashboard](https://app.banana.dev) and setup your account by saving your payment details and linking your Github.
 
-4. Make sure your Dockerfile has the Huggingface auth token added as an environment variable.
+4. Create huggingface account to get permission to download and run [Stable Diffusion](https://huggingface.co/CompVis/stable-diffusion-v1-4) text-to-image model.
+  - Accept terms and conditions for the use of the v1-4 [Stable Diffusion](https://huggingface.co/CompVis/stable-diffusion-v1-4)
+
+5. Edit the `dockerfile` in your forked repo with `ENV HF_AUTH_TOKEN=your_auth_token`
+
+6. Push that repo to main.
 
 From then onward, any pushes to the default repo branch (usually "main" or "master") trigger Banana to build and deploy your server, using the Dockerfile.
 Throughout the build we'll sprinkle in some secret sauce to make your server extra snappy 🔥

--- a/download.py
+++ b/download.py
@@ -20,6 +20,6 @@ def download_model():
         scheduler=lms,
         use_auth_token=HF_AUTH_TOKEN
     )
-
+g
 if __name__ == "__main__":
     download_model()


### PR DESCRIPTION
# What is this?
Updating the template readme so that it contains all the steps needed for stable diffusion, and none of the steps needed for non-stable-diffusion

# Why?
User ran into many roadblocks while deploying and it was because of this readme and dockerfile not being concise and clear.

# How did you test it? 
Building locally now, will confirm