### PR TITLE
Add modelInputs width, height, num_inference_steps, guidance_scale

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,10 +25,21 @@ def inference(model_inputs:dict) -> dict:
     prompt = model_inputs.get('prompt', None)
     if prompt == None:
         return {'message': "No prompt provided"}
+
+    height = model_inputs.get('height', 512);
+    width = model_inputs.get('width', 512);
+    num_inference_steps = model_inputs.get('num_inference_steps', 50);
+    guidance_scale = model_inputs.get('guidance_scale', 7.5);
     
     # Run the model
     with autocast("cuda"):
-        image = model(prompt)["sample"][0]
+        image = model(
+            prompt=prompt,
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+        )["sample"][0]
     
     buffered = BytesIO()
     image.save(buffered,format="JPEG")


### PR DESCRIPTION
# What is this?

Passes on some common model inputs (`width`, `height`, `num_inference_steps`, `guidance_scale`).

# Why?

They're useful :)

# How did you test it? 

Have been running locally in https://github.com/gadicc/stable-diffusion-react-nextjs-mui-pwa for a few days, and deployed.

# Comments

1. I have almost no Python experience, please comment on any styling / convention inconsistencies.
2. I used the defaults I found online, not sure if there's a better way to allow empty values and let the model itself use its defaults.
3. If this is all good I'll do the `init_image` and `strength` (iirc) stuff next when I get to that part of my app.

No urgency from my side, already running this deployed, but figured it would be useful for others.
