### PR TITLE
Add new schedulers, multiple image generation and negative prompt

### DIFF
--- a/download.py
+++ b/download.py
@@ -1,7 +1,7 @@
 # In this file, we define download_model
 # It runs during container build time to get model weights built into the container
 
-from diffusers import StableDiffusionPipeline, LMSDiscreteScheduler
+from diffusers import StableDiffusionPipeline
 import os
 
 def download_model():
@@ -9,15 +9,8 @@ def download_model():
     #Set auth token which is required to download stable diffusion model weights
     HF_AUTH_TOKEN = os.getenv("HF_AUTH_TOKEN")
 
-    lms = LMSDiscreteScheduler(
-        beta_start=0.00085, 
-        beta_end=0.012, 
-        beta_schedule="scaled_linear"
-    )
-
     model = StableDiffusionPipeline.from_pretrained(
         "CompVis/stable-diffusion-v1-4", 
-        scheduler=lms,
         use_auth_token=HF_AUTH_TOKEN
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 sanic==22.6.2
-diffusers==0.2.3
+diffusers==0.7.0
 transformers
 scipy
+ftfy
+accelerate

--- a/test.py
+++ b/test.py
@@ -10,7 +10,7 @@ model_inputs = {'prompt': 'realistic field of grass'}
 
 res = requests.post('http://localhost:8000/', json = model_inputs)
 
-image_byte_string = res.json()["image_base64"]
+image_byte_string = res.json()["images_base64"]
 
 image_encoded = image_byte_string.encode('utf-8')
 image_bytes = BytesIO(base64.b64decode(image_encoded))

--- a/test.py
+++ b/test.py
@@ -6,11 +6,11 @@ import base64
 from io import BytesIO
 from PIL import Image
 
-model_inputs = {'prompt': 'realistic field of grass'}
+model_inputs = {'seed': 789, 'prompt': 'Ragdoll cat king wearing a golden crown, intricate, elegant, highly detailed, centered, digital painting, artstation, concept art, smooth, sharp focus, illustration, artgerm, Tomasz Alen Kopera, Peter Mohrbacher, donato giancola, Joseph Christian Leyendecker, WLOP, Boris Vallejo'}
 
 res = requests.post('http://localhost:8000/', json = model_inputs)
 
-image_byte_string = res.json()["images_base64"]
+image_byte_string = res.json()["images_base64"][0]
 
 image_encoded = image_byte_string.encode('utf-8')
 image_bytes = BytesIO(base64.b64decode(image_encoded))


### PR DESCRIPTION
# What is this?

1. In this PR I've upgraded the `diffusers` library to the latest one - [v0.7.0](https://github.com/huggingface/diffusers/releases/tag/v0.7.0)
2. Added [ftfy](https://pypi.org/project/ftfy/) text encoder as a required dependency
3. Added support for new params: `negative_prompt`, `num_images_per_prompt`, `scheduler`
4. Added support for setting a custom scheduler. One of LMSDiscreteScheduler, EulerAncestralDiscreteScheduler (added in v0.7.0 diffusers lib), EulerDiscreteScheduler (added in v0.7.0 diffusers lib), DDIMScheduler, PNDMScheduler
5. Added multiple image generation support

# Why?
Banana.dev did a lot for the Stable Diffusion community. 
With this PR we want to improve the default template for custom models, that other community members can use without extra setup for custom schedulers, multiple image generation, and other useful parameters.

# How did you test to ensure no regressions?
I've used [brev console](https://console.brev.dev/) for testing.
<img width="523" alt="Screenshot 2022-11-04 at 16 10 47" src="https://user-images.githubusercontent.com/22455666/200009404-80eb5a7b-f122-4fc0-b308-57c1e3e6ceca.png">

# If this is a new feature what is one way you can make this break?
This is a new feature, and instead of a single image `{"image_base64": image_base64}` it now returns an array of images `{"image**s**_base64": image**s**_base64}`

# Testing results:
Below are my testing results with different schedulers with default settings and other custom input:

**prompt:**
_Ragdoll cat king wearing a golden crown, intricate, elegant, highly detailed, centered, digital painting, artstation, concept art, smooth, sharp focus, illustration, artgerm, Tomasz Alen Kopera, Peter Mohrbacher, donato giancola, Joseph Christian Leyendecker, WLOP, Boris Vallejo_

**seed:** _789_

<img width="761" alt="Screenshot 2022-11-04 at 15 57 18" src="https://user-images.githubusercontent.com/22455666/200009710-a6b13107-3b22-4d5e-a494-2d0ae17971dc.png">